### PR TITLE
Add FIFA World Cup 2026 bracket predictor (Playground)

### DIFF
--- a/web/src/components/page-sidebar.tsx
+++ b/web/src/components/page-sidebar.tsx
@@ -1,52 +1,44 @@
 
 import { Sidebar as BaseSidebar, SidebarContent, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarInset, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
-import { ArrowLeftRight, BookLock, Code, Gamepad2, Home, MonitorUp, Newspaper } from "lucide-react";
+import { ArrowLeftRight, BookLock, ChevronRight, Code, Gamepad2, Home, MonitorUp, Newspaper, Trophy } from "lucide-react";
 import React from "react";
 
 type SidebarProps = {
     children: React.ReactNode
 }
 
+type Item = { title: string; url: string; icon: React.ComponentType };
+
 export function Sidebar({ children }: SidebarProps) {
     // TODO: probably move sidebar to page level and let page add custom sidebar items under a new "section"
     // so domains/pages can have custom sidebar segments
-    const items = [
-        {
-            title: "Home",
-            url: "/",
-            icon: Home,
-        },
-        {
-            title: "Blog",
-            url: "/blog",
-            icon: Newspaper,
-        },
-        {
-            title: "Editor",
-            url: "/edit",
-            icon: Code,
-        },
-        {
-            title: "Secret",
-            url: "/secret",
-            icon: BookLock,
-        },
-        {
-            title: "Swap",
-            url: "/swap",
-            icon: ArrowLeftRight,
-        },
-        {
-            title: "Share",
-            url: "/share",
-            icon: MonitorUp,
-        },
-        {
-            title: "Ping",
-            url: "/ping",
-            icon: Gamepad2,
-        },
+    const items: Item[] = [
+        { title: "Home", url: "/", icon: Home },
+        { title: "Blog", url: "/blog", icon: Newspaper },
+        { title: "Editor", url: "/edit", icon: Code },
+        { title: "Secret", url: "/secret", icon: BookLock },
+        { title: "Swap", url: "/swap", icon: ArrowLeftRight },
+        { title: "Share", url: "/share", icon: MonitorUp },
     ];
+
+    // "Playground" — small standalone toys/experiments. Expanded by default.
+    const playground: Item[] = [
+        { title: "Ping", url: "/ping", icon: Gamepad2 },
+        { title: "FIFA Bracket", url: "/fifa", icon: Trophy },
+    ];
+
+    const [playgroundOpen, setPlaygroundOpen] = React.useState(true);
+
+    const renderItem = (item: Item) => (
+        <SidebarMenuItem key={item.title}>
+            <SidebarMenuButton asChild>
+                <a href={item.url}>
+                    <item.icon />
+                    <span>{item.title}</span>
+                </a>
+            </SidebarMenuButton>
+        </SidebarMenuItem>
+    );
 
     return (
         <>
@@ -56,18 +48,32 @@ export function Sidebar({ children }: SidebarProps) {
                         <SidebarGroupLabel>Lystic's Platform</SidebarGroupLabel>
                         <SidebarGroupContent>
                             <SidebarMenu>
-                                {items.map((item) => (
-                                    <SidebarMenuItem key={item.title}>
-                                        <SidebarMenuButton asChild>
-                                            <a href={item.url}>
-                                                <item.icon />
-                                                <span>{item.title}</span>
-                                            </a>
-                                        </SidebarMenuButton>
-                                    </SidebarMenuItem>
-                                ))}
+                                {items.map(renderItem)}
                             </SidebarMenu>
                         </SidebarGroupContent>
+                    </SidebarGroup>
+
+                    <SidebarGroup>
+                        <SidebarGroupLabel asChild>
+                            <button
+                                type="button"
+                                aria-expanded={playgroundOpen}
+                                onClick={() => setPlaygroundOpen((o) => !o)}
+                                className="flex w-full cursor-pointer items-center justify-between gap-2 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                            >
+                                <span>Playground</span>
+                                <ChevronRight
+                                    className={`!size-3.5 shrink-0 opacity-60 transition-transform duration-200 ${playgroundOpen ? "rotate-90" : ""}`}
+                                />
+                            </button>
+                        </SidebarGroupLabel>
+                        {playgroundOpen && (
+                            <SidebarGroupContent>
+                                <SidebarMenu>
+                                    {playground.map(renderItem)}
+                                </SidebarMenu>
+                            </SidebarGroupContent>
+                        )}
                     </SidebarGroup>
                 </SidebarContent>
             </BaseSidebar>

--- a/web/src/pages/domain-router.tsx
+++ b/web/src/pages/domain-router.tsx
@@ -3,6 +3,7 @@ import { SubdomainProvider, useSubdomain } from "@/context/subdomain-provider"; 
 
 import { BlogRouter } from "@/pages/blog/router";
 import { EditRouter } from "@/pages/edit/router";
+import { FifaRouter } from "@/pages/fifa";
 import { HomeRouter } from "@/pages/home/router";
 import { PingRouter } from "@/pages/ping";
 import { SecretRouter } from "@/pages/secret/router";
@@ -20,6 +21,7 @@ export const SERVICE_ROUTERS: Record<string, React.FC> = {
     swap: SwapRouter,
     share: ShareRouter,
     ping: PingRouter,
+    fifa: FifaRouter,
 };
 
 function GetPageRouter(subdomain: string): React.FC {

--- a/web/src/pages/fifa/bracket.ts
+++ b/web/src/pages/fifa/bracket.ts
@@ -1,0 +1,179 @@
+/* ===========================================================
+   World Cup 2026 — Knockout Bracket: pure data + logic.
+   No DOM / React here so it stays trivially testable and the
+   share codec can decode into a scratch map before it goes live.
+   Bracket verified against the official Round of 32 draw.
+   =========================================================== */
+
+export type Team = { n: string; c: string };
+export type SlotKey = "a" | "b";
+export type SlotRef = { t: string } | { from: number };
+export type Match = { a: SlotRef; b: SlotRef };
+export type Winners = Record<number, string>;
+export type Side = "left" | "center" | "right";
+export type Column = { side: Side; title: string; ids: number[] };
+
+// Teams: ISO 3166-1 alpha-2 codes drive flag images from flagcdn.com.
+export const T: Record<string, Team> = {
+  ZA: { n: "South Africa", c: "za" }, CA: { n: "Canada", c: "ca" },
+  DE: { n: "Germany", c: "de" }, PY: { n: "Paraguay", c: "py" },
+  NL: { n: "Netherlands", c: "nl" }, MA: { n: "Morocco", c: "ma" },
+  BR: { n: "Brazil", c: "br" }, JP: { n: "Japan", c: "jp" },
+  FR: { n: "France", c: "fr" }, SE: { n: "Sweden", c: "se" },
+  CI: { n: "Ivory Coast", c: "ci" }, NO: { n: "Norway", c: "no" },
+  MX: { n: "Mexico", c: "mx" }, EC: { n: "Ecuador", c: "ec" },
+  EN: { n: "England", c: "gb-eng" }, CD: { n: "DR Congo", c: "cd" },
+  US: { n: "United States", c: "us" }, BA: { n: "Bosnia & Herz.", c: "ba" },
+  BE: { n: "Belgium", c: "be" }, SN: { n: "Senegal", c: "sn" },
+  ES: { n: "Spain", c: "es" }, AT: { n: "Austria", c: "at" },
+  PT: { n: "Portugal", c: "pt" }, HR: { n: "Croatia", c: "hr" },
+  CH: { n: "Switzerland", c: "ch" }, DZ: { n: "Algeria", c: "dz" },
+  AR: { n: "Argentina", c: "ar" }, CV: { n: "Cape Verde", c: "cv" },
+  CO: { n: "Colombia", c: "co" }, GH: { n: "Ghana", c: "gh" },
+  AU: { n: "Australia", c: "au" }, EG: { n: "Egypt", c: "eg" },
+};
+
+// Each match: a/b slots are either a fixed team {t} (Round of 32)
+// or fed by the winner of an earlier match {from}.
+export const MATCHES: Record<number, Match> = {
+  // Round of 32
+  73: { a: { t: "ZA" }, b: { t: "CA" } },
+  74: { a: { t: "DE" }, b: { t: "PY" } },
+  75: { a: { t: "NL" }, b: { t: "MA" } },
+  76: { a: { t: "BR" }, b: { t: "JP" } },
+  77: { a: { t: "FR" }, b: { t: "SE" } },
+  78: { a: { t: "CI" }, b: { t: "NO" } },
+  79: { a: { t: "MX" }, b: { t: "EC" } },
+  80: { a: { t: "EN" }, b: { t: "CD" } },
+  81: { a: { t: "US" }, b: { t: "BA" } },
+  82: { a: { t: "BE" }, b: { t: "SN" } },
+  83: { a: { t: "ES" }, b: { t: "AT" } },
+  84: { a: { t: "PT" }, b: { t: "HR" } },
+  85: { a: { t: "CH" }, b: { t: "DZ" } },
+  86: { a: { t: "AR" }, b: { t: "CV" } },
+  87: { a: { t: "CO" }, b: { t: "GH" } },
+  88: { a: { t: "AU" }, b: { t: "EG" } },
+  // Round of 16
+  89: { a: { from: 74 }, b: { from: 77 } },
+  90: { a: { from: 73 }, b: { from: 75 } },
+  91: { a: { from: 76 }, b: { from: 78 } },
+  92: { a: { from: 79 }, b: { from: 80 } },
+  93: { a: { from: 83 }, b: { from: 84 } },
+  94: { a: { from: 81 }, b: { from: 82 } },
+  95: { a: { from: 86 }, b: { from: 88 } },
+  96: { a: { from: 85 }, b: { from: 87 } },
+  // Quarter-finals
+  97: { a: { from: 89 }, b: { from: 90 } },
+  98: { a: { from: 93 }, b: { from: 94 } },
+  99: { a: { from: 91 }, b: { from: 92 } },
+  100: { a: { from: 95 }, b: { from: 96 } },
+  // Semi-finals
+  101: { a: { from: 97 }, b: { from: 98 } },
+  102: { a: { from: 99 }, b: { from: 100 } },
+  // Final
+  104: { a: { from: 101 }, b: { from: 102 } },
+};
+
+export const FINAL_ID = 104;
+
+// Visual column layout (left half → final → right half, mirrored).
+export const COLUMNS: Column[] = [
+  { side: "left", title: "Round of 32", ids: [74, 77, 73, 75, 83, 84, 81, 82] },
+  { side: "left", title: "Round of 16", ids: [89, 90, 93, 94] },
+  { side: "left", title: "Quarter-finals", ids: [97, 98] },
+  { side: "left", title: "Semi-finals", ids: [101] },
+  { side: "center", title: "Final", ids: [104] },
+  { side: "right", title: "Semi-finals", ids: [102] },
+  { side: "right", title: "Quarter-finals", ids: [99, 100] },
+  { side: "right", title: "Round of 16", ids: [91, 92, 95, 96] },
+  { side: "right", title: "Round of 32", ids: [76, 78, 79, 80, 86, 88, 85, 87] },
+];
+
+// Stable dependency order (feeders before the matches they feed) — used for
+// both simulate and the share-link codec.
+export const ORDERED_IDS = Object.keys(MATCHES).map(Number).sort((a, b) => a - b);
+export const TOTAL_MATCHES = ORDERED_IDS.length; // 31
+
+export function flagUrl(code: string, size: "w40" | "w80" = "w40"): string {
+  return `https://flagcdn.com/${size}/${code}.png`;
+}
+
+// Resolve a slot's team against an arbitrary winners map.
+export function slotTeam(winners: Winners, matchId: number, slot: SlotKey): string | null {
+  const s = MATCHES[matchId][slot];
+  if ("t" in s) return s.t;        // fixed Round-of-32 team
+  return winners[s.from] ?? null;  // winner of a feeder match (may be null)
+}
+
+// Return a copy with any now-invalid winner removed, cascading downstream
+// until the state is consistent.
+export function reconcile(winners: Winners): Winners {
+  const w: Winners = { ...winners };
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const key of Object.keys(w)) {
+      const id = Number(key);
+      const a = slotTeam(w, id, "a");
+      const b = slotTeam(w, id, "b");
+      if (w[id] !== a && w[id] !== b) {
+        delete w[id];
+        changed = true;
+      }
+    }
+  }
+  return w;
+}
+
+/* ---------- Share codec ----------
+   One char per match in ORDERED_IDS: '0' none, '1' slot A, '2' slot B. */
+export function encodeState(winners: Winners): string {
+  return ORDERED_IDS.map((id) => {
+    if (winners[id] === slotTeam(winners, id, "a")) return "1";
+    if (winners[id] === slotTeam(winners, id, "b")) return "2";
+    return "0";
+  }).join("");
+}
+
+export function decodeState(str: string | null | undefined): Winners {
+  const w: Winners = {};
+  if (!str || str.length !== ORDERED_IDS.length) return w;
+  ORDERED_IDS.forEach((id, i) => {
+    const v = str[i];
+    const slot: SlotKey | null = v === "1" ? "a" : v === "2" ? "b" : null;
+    if (!slot) return;
+    const t = slotTeam(w, id, slot); // upstream already filled (dep order)
+    if (t) w[id] = t;
+  });
+  return w;
+}
+
+// Random fill of every match, respecting dependency order.
+export function simulateWinners(): Winners {
+  const w: Winners = {};
+  for (const id of ORDERED_IDS) {
+    const a = slotTeam(w, id, "a");
+    const b = slotTeam(w, id, "b");
+    if (a && b) w[id] = Math.random() < 0.5 ? a : b;
+  }
+  return w;
+}
+
+// Short, paste-friendly recap so a shared link isn't opaque in a chat.
+export function bracketSummary(winners: Winners): string {
+  const champ = winners[FINAL_ID];
+  if (champ) {
+    const fa = slotTeam(winners, FINAL_ID, "a");
+    const fb = slotTeam(winners, FINAL_ID, "b");
+    const runnerKey = champ === fa ? fb : fa;
+    const tail = runnerKey ? ` (beat ${T[runnerKey].n} in the final)` : "";
+    return `🏆 My World Cup 2026 bracket — Champion: ${T[champ].n}${tail}`;
+  }
+  return `My World Cup 2026 bracket — ${Object.keys(winners).length}/${TOTAL_MATCHES} picked`;
+}
+
+export function chunkPairs(ids: number[]): number[][] {
+  const out: number[][] = [];
+  for (let i = 0; i < ids.length; i += 2) out.push(ids.slice(i, i + 2));
+  return out;
+}

--- a/web/src/pages/fifa/fifa-page.tsx
+++ b/web/src/pages/fifa/fifa-page.tsx
@@ -1,0 +1,355 @@
+import { Maximize2, Minimize2, RotateCcw, Share2, Shuffle, Trophy, Undo2 } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { Header } from "@/components/page-header";
+import { PageMeta } from "@/components/page-meta";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+import {
+    bracketSummary,
+    chunkPairs,
+    COLUMNS,
+    type Column,
+    decodeState,
+    encodeState,
+    FINAL_ID,
+    flagUrl,
+    reconcile,
+    simulateWinners,
+    slotTeam,
+    T,
+    TOTAL_MATCHES,
+    type Winners,
+} from "./bracket";
+import "./fifa.css";
+
+const STORAGE_KEY = "wc2026-bracket-picks";
+const FIT_MIN_WIDTH = 1024;
+
+function readHash(): Winners | null {
+    if (typeof window === "undefined") return null;
+    const m = /[#&?]b=([012]+)/.exec(window.location.hash);
+    return m ? decodeState(m[1]) : null;
+}
+
+function loadInitial(): Winners {
+    const fromUrl = readHash(); // a shared link wins over local storage
+    if (fromUrl && Object.keys(fromUrl).length) return fromUrl;
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? reconcile(JSON.parse(raw)) : {};
+    } catch {
+        return {};
+    }
+}
+
+function persist(winners: Winners) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(winners));
+    } catch { /* ignore quota/private-mode */ }
+    // keep the URL hash in sync so the page is always shareable / refresh-safe
+    try {
+        const code = encodeState(winners);
+        const base = window.location.pathname + window.location.search;
+        const url = Object.keys(winners).length ? `${base}#b=${code}` : base;
+        window.history.replaceState(null, "", url);
+    } catch { /* ignore */ }
+}
+
+function ChampionBanner({ winners }: { winners: Winners }) {
+    const champ = winners[FINAL_ID];
+    if (!champ) return null;
+    const team = T[champ];
+    const fa = slotTeam(winners, FINAL_ID, "a");
+    const fb = slotTeam(winners, FINAL_ID, "b");
+    const runnerKey = champ === fa ? fb : fa;
+    const runner = runnerKey ? T[runnerKey] : null;
+    return (
+        <div className="fifa-champion" role="status" aria-live="polite">
+            <span className="fifa-c-trophy" aria-hidden>🏆</span>
+            <div className="fifa-c-body">
+                <div className="fifa-c-label">World Cup 2026 Champions</div>
+                <div className="fifa-c-name">
+                    <img src={flagUrl(team.c)} alt="" /> {team.n}
+                </div>
+                {runner && (
+                    <div className="fifa-c-sub">
+                        defeated <img src={flagUrl(runner.c)} alt="" /> {runner.n} in the final
+                    </div>
+                )}
+            </div>
+            <span className="fifa-c-trophy" aria-hidden>🏆</span>
+        </div>
+    );
+}
+
+export function FifaPage() {
+    const [winners, setWinners] = useState<Winners>(loadInitial);
+    const [undoStack, setUndoStack] = useState<string[]>([]);
+    const [fitMode, setFitMode] = useState<boolean>(
+        () => typeof window !== "undefined" && window.innerWidth >= FIT_MIN_WIDTH,
+    );
+    const [shareLabel, setShareLabel] = useState<string | null>(null);
+
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const bracketRef = useRef<HTMLDivElement>(null);
+    const userSetFitRef = useRef(false);
+
+    const breadcrumbs = [{ label: "lystic.dev/fifa" }];
+    const champ = winners[FINAL_ID];
+    const pickedCount = Object.keys(winners).length;
+
+    useEffect(() => {
+        persist(winners);
+    }, [winners]);
+
+    const commit = useCallback(
+        (next: Winners) => {
+            setUndoStack((s) => [...s, JSON.stringify(winners)].slice(-100));
+            setWinners(reconcile(next));
+        },
+        [winners],
+    );
+
+    const pick = useCallback(
+        (matchId: number, teamKey: string) => {
+            if (winners[matchId] === teamKey) return;
+            commit({ ...winners, [matchId]: teamKey });
+        },
+        [winners, commit],
+    );
+
+    const undo = useCallback(() => {
+        if (!undoStack.length) return;
+        const prev = undoStack[undoStack.length - 1];
+        setUndoStack(undoStack.slice(0, -1));
+        setWinners(reconcile(JSON.parse(prev)));
+    }, [undoStack]);
+
+    const simulate = useCallback(() => commit(simulateWinners()), [commit]);
+    const reset = useCallback(() => {
+        if (pickedCount) commit({});
+    }, [commit, pickedCount]);
+
+    const share = useCallback(() => {
+        persist(winners);
+        const text = `${bracketSummary(winners)}\n${window.location.href}`;
+        const flash = (m: string) => {
+            setShareLabel(m);
+            window.setTimeout(() => setShareLabel(null), 1600);
+        };
+        if (navigator.clipboard?.writeText) {
+            navigator.clipboard.writeText(text).then(
+                () => flash("Copied"),
+                () => flash("Copy failed"),
+            );
+        } else {
+            flash("Copy failed");
+        }
+    }, [winners]);
+
+    const toggleFit = () => {
+        userSetFitRef.current = true;
+        setFitMode((f) => !f);
+    };
+
+    // Scale the bracket to fit the content area (like Ping's canvas), or let it
+    // scroll at full size on narrow screens where fitting makes it unreadable.
+    const applyFit = useCallback(() => {
+        const scroll = scrollRef.current;
+        const bracket = bracketRef.current;
+        if (!scroll || !bracket) return;
+
+        // The site's SidebarInset grows with content and page-scrolls, and the
+        // bracket's min-height keeps a tall layout box even while transform-scaled.
+        // Pin our <main> to the viewport (minus the page header) so the bracket
+        // area is bounded and the page never scrolls into empty space.
+        const main = scroll.parentElement;
+        if (main) {
+            const header = main.previousElementSibling as HTMLElement | null;
+            const headerH = header ? Math.round(header.getBoundingClientRect().height) : 56;
+            // flex-1 would let the flex algorithm override an explicit height, so
+            // pin it to a fixed box instead.
+            main.style.flex = "0 0 auto";
+            main.style.height = `calc(100svh - ${headerH}px)`;
+        }
+
+        bracket.style.transform = "";
+        bracket.style.marginLeft = "";
+        bracket.style.marginTop = "";
+        if (!fitMode) {
+            scroll.style.overflow = "auto";
+            return;
+        }
+        const nw = bracket.offsetWidth;
+        const nh = bracket.offsetHeight;
+        const cs = getComputedStyle(scroll);
+        const padX = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+        const padY = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
+        const availW = scroll.clientWidth - padX;
+        const availH = scroll.clientHeight - padY;
+        if (availW <= 0 || availH <= 0 || nw <= 0) return;
+        const scale = Math.min(availW / nw, availH / nh, 1.35);
+        bracket.style.transformOrigin = "top left";
+        bracket.style.transform = `scale(${scale})`;
+        // center horizontally, but sit near the top so the embedded page doesn't
+        // open with a big empty gap under the controls
+        bracket.style.marginLeft = `${Math.max(0, (availW - nw * scale) / 2)}px`;
+        bracket.style.marginTop = "0px";
+        scroll.style.overflow = "hidden";
+    }, [fitMode]);
+
+    useLayoutEffect(() => {
+        applyFit();
+        const scroll = scrollRef.current;
+        if (!scroll) return;
+        const ro = new ResizeObserver(() => applyFit());
+        ro.observe(scroll);
+        return () => ro.disconnect();
+    }, [applyFit]);
+
+    // re-fit when the champion banner toggles (changes the area above the bracket)
+    useLayoutEffect(() => {
+        applyFit();
+    }, [champ, applyFit]);
+
+    // follow the breakpoint on resize until the user manually picks a mode
+    useEffect(() => {
+        const onResize = () => {
+            if (userSetFitRef.current) return;
+            const want = window.innerWidth >= FIT_MIN_WIDTH;
+            setFitMode((prev) => (prev === want ? prev : want));
+        };
+        window.addEventListener("resize", onResize);
+        return () => window.removeEventListener("resize", onResize);
+    }, []);
+
+    const renderSlot = (matchId: number, slot: "a" | "b") => {
+        const teamKey = slotTeam(winners, matchId, slot);
+        const decided = winners[matchId] != null;
+        if (!teamKey) {
+            return (
+                <div className="fifa-slot fifa-empty" aria-hidden key={slot}>
+                    <span className="fifa-flag ph" />
+                    <span className="fifa-name">TBD</span>
+                </div>
+            );
+        }
+        const team = T[teamKey];
+        const isWinner = winners[matchId] === teamKey;
+        const cls = ["fifa-slot"];
+        if (decided) cls.push("decided");
+        if (isWinner) cls.push("winner");
+        else if (decided) cls.push("loser");
+        if (champ && isWinner && teamKey === champ) cls.push("champ-path");
+        return (
+            <button
+                key={slot}
+                type="button"
+                className={cls.join(" ")}
+                aria-pressed={isWinner}
+                aria-label={(isWinner ? "Winner: " : "Pick ") + team.n}
+                onClick={() => pick(matchId, teamKey)}
+            >
+                <img
+                    className="fifa-flag"
+                    loading="lazy"
+                    src={flagUrl(team.c)}
+                    srcSet={`${flagUrl(team.c, "w80")} 2x`}
+                    alt=""
+                />
+                <span className="fifa-name">{team.n}</span>
+            </button>
+        );
+    };
+
+    const renderMatch = (matchId: number) => {
+        const pending = !slotTeam(winners, matchId, "a") && !slotTeam(winners, matchId, "b");
+        return (
+            <div className={`fifa-match${pending ? " pending" : ""}`} key={matchId}>
+                {renderSlot(matchId, "a")}
+                {renderSlot(matchId, "b")}
+                <span className="fifa-match-no">M{matchId}</span>
+            </div>
+        );
+    };
+
+    const renderColumn = (col: Column, i: number) => (
+        <section className={`fifa-col ${col.side}`} key={i}>
+            <div className="fifa-col-title">{col.title}</div>
+            <div className="fifa-col-body">
+                {col.ids.length === 1 ? (
+                    <div className="fifa-pair solo">{renderMatch(col.ids[0])}</div>
+                ) : (
+                    chunkPairs(col.ids).map((g, gi) => (
+                        <div className="fifa-pair" key={gi}>
+                            {g.map(renderMatch)}
+                        </div>
+                    ))
+                )}
+            </div>
+        </section>
+    );
+
+    return (
+        <>
+            <PageMeta
+                title="FIFA Bracket — World Cup 2026 predictor"
+                description="Pick the winners of every World Cup 2026 knockout match and share your bracket."
+            />
+            <Header breadcrumbItems={breadcrumbs} />
+            <main className="fifa flex flex-1 flex-col overflow-hidden">
+                <div className="fifa-topbar">
+                    <div className="fifa-title">
+                        <Trophy className="fifa-title-icon" aria-hidden />
+                        <span>
+                            World Cup <span className="fifa-year">2026</span> Bracket
+                        </span>
+                    </div>
+                    <div className="fifa-controls">
+                        <Badge
+                            variant="outline"
+                            className={`fifa-progress${pickedCount === TOTAL_MATCHES ? " complete" : ""}`}
+                        >
+                            {pickedCount} / {TOTAL_MATCHES} picked
+                        </Badge>
+                        <Button
+                            variant={fitMode ? "secondary" : "outline"}
+                            size="sm"
+                            onClick={toggleFit}
+                            aria-pressed={fitMode}
+                        >
+                            {fitMode ? <Minimize2 /> : <Maximize2 />}
+                            {fitMode ? "Fit" : "Full size"}
+                        </Button>
+                        <Button variant="outline" size="sm" onClick={simulate}>
+                            <Shuffle /> Simulate
+                        </Button>
+                        <Button variant="outline" size="sm" onClick={undo} disabled={!undoStack.length}>
+                            <Undo2 /> Undo
+                        </Button>
+                        <Button variant="outline" size="sm" onClick={reset} disabled={!pickedCount}>
+                            <RotateCcw /> Reset
+                        </Button>
+                        <Button variant="default" size="sm" onClick={share}>
+                            <Share2 /> {shareLabel ?? "Share"}
+                        </Button>
+                    </div>
+                </div>
+
+                <ChampionBanner winners={winners} />
+
+                <div ref={scrollRef} className="fifa-scroll flex-1 min-h-0">
+                    <div ref={bracketRef} className="fifa-bracket">
+                        {COLUMNS.map(renderColumn)}
+                    </div>
+                </div>
+
+                {!fitMode && (
+                    <div className="fifa-hint">Scroll to explore the full bracket →</div>
+                )}
+            </main>
+        </>
+    );
+}

--- a/web/src/pages/fifa/fifa.css
+++ b/web/src/pages/fifa/fifa.css
@@ -1,0 +1,365 @@
+/* World Cup 2026 bracket — scoped under .fifa.
+   Hybrid theme: chrome follows the site's light/dark tokens
+   (--background, --card, --border, --foreground, --muted-foreground),
+   while wins/champion/connectors keep a World-Cup gold accent. */
+
+.fifa {
+    --wc-gold: #f0a824;
+    --wc-gold-soft: #ffce5a;
+    --wc-line: color-mix(in srgb, var(--wc-gold) 55%, transparent);
+    --wc-gap: 40px;
+    --wc-col-w: 184px;
+}
+
+/* ---------- Top bar ---------- */
+.fifa-topbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px 20px 10px;
+}
+.fifa-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 800;
+    font-size: clamp(18px, 2.4vw, 26px);
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    color: var(--foreground);
+}
+.fifa-title-icon {
+    width: 1.1em;
+    height: 1.1em;
+    color: var(--wc-gold);
+}
+.fifa-year { color: var(--wc-gold); }
+.fifa-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+.fifa-progress {
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+}
+.fifa-progress.complete {
+    color: var(--wc-gold);
+    border-color: color-mix(in srgb, var(--wc-gold) 55%, transparent);
+    background: color-mix(in srgb, var(--wc-gold) 14%, transparent);
+}
+
+/* ---------- Champion banner ---------- */
+.fifa-champion {
+    position: relative;
+    overflow: hidden;
+    margin: 4px 20px 0;
+    padding: 12px 20px;
+    border-radius: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    background: linear-gradient(
+        100deg,
+        color-mix(in srgb, var(--wc-gold) 22%, var(--card)),
+        color-mix(in srgb, var(--wc-gold) 8%, var(--card))
+    );
+    border: 1px solid color-mix(in srgb, var(--wc-gold) 55%, transparent);
+    box-shadow: 0 10px 34px color-mix(in srgb, var(--wc-gold) 16%, transparent);
+    animation: fifa-pop 0.35s ease;
+}
+.fifa-champion::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -60%;
+    width: 40%;
+    height: 100%;
+    background: linear-gradient(100deg, transparent, color-mix(in srgb, var(--wc-gold-soft) 35%, transparent), transparent);
+    transform: skewX(-18deg);
+    animation: fifa-sweep 3.4s ease-in-out infinite;
+}
+.fifa-c-trophy { font-size: 32px; line-height: 1; }
+.fifa-c-body { text-align: center; }
+.fifa-c-label {
+    font-size: 12px;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--wc-gold);
+    font-weight: 700;
+}
+.fifa-c-name {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    font-weight: 800;
+    text-transform: uppercase;
+    font-size: clamp(22px, 3vw, 32px);
+    color: var(--foreground);
+}
+.fifa-c-name img {
+    width: 42px;
+    border-radius: 5px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+.fifa-c-sub {
+    margin-top: 3px;
+    font-size: 13px;
+    color: var(--muted-foreground);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+}
+.fifa-c-sub img { width: 20px; border-radius: 3px; }
+
+/* ---------- Bracket grid ---------- */
+.fifa-scroll {
+    overflow: auto;
+    padding: 18px 22px 12px;
+}
+.fifa-bracket {
+    display: flex;
+    gap: var(--wc-gap);
+    min-height: 720px;
+    width: max-content;
+    margin: 0 auto;
+    padding: 4px;
+}
+.fifa-col {
+    width: var(--wc-col-w);
+    display: flex;
+    flex-direction: column;
+    flex: 0 0 auto;
+}
+.fifa-col-title {
+    text-align: center;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--muted-foreground);
+    padding-bottom: 12px;
+    white-space: nowrap;
+}
+.fifa-col.center .fifa-col-title {
+    color: var(--wc-gold);
+    letter-spacing: 0.2em;
+}
+.fifa-col-body {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    flex: 1;
+}
+.fifa-pair {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    flex: 1;
+    position: relative;
+}
+.fifa-pair.solo { justify-content: center; }
+
+/* ---------- Match cards ---------- */
+.fifa-match {
+    position: relative;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 11px;
+    overflow: hidden;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+}
+.fifa-col.center .fifa-match {
+    border-color: color-mix(in srgb, var(--wc-gold) 55%, transparent);
+    box-shadow: 0 8px 26px color-mix(in srgb, var(--wc-gold) 18%, transparent);
+}
+.fifa-match.pending {
+    background: transparent;
+    border-color: color-mix(in srgb, var(--border) 55%, transparent);
+    box-shadow: none;
+}
+.fifa-col.center .fifa-match.pending {
+    border-color: color-mix(in srgb, var(--wc-gold) 30%, transparent);
+    box-shadow: none;
+}
+
+.fifa-slot {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    color: var(--foreground);
+    width: 100%;
+    text-align: left;
+    font: inherit;
+    transition: background 0.16s ease;
+}
+.fifa-slot + .fifa-slot { border-top: 1px solid var(--border); }
+.fifa-slot:hover:not(.fifa-empty) {
+    background: color-mix(in srgb, var(--foreground) 8%, transparent);
+}
+.fifa-empty { cursor: default; color: var(--muted-foreground); }
+
+.fifa-flag {
+    width: 28px;
+    height: 19px;
+    border-radius: 3px;
+    object-fit: cover;
+    flex: 0 0 auto;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+    background: color-mix(in srgb, var(--foreground) 6%, transparent);
+}
+.fifa-flag.ph {
+    display: inline-block;
+    border: 1px dashed var(--border);
+    box-shadow: none;
+}
+.fifa-name {
+    font-weight: 600;
+    font-size: 15px;
+    letter-spacing: 0.01em;
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.fifa-slot.winner {
+    background: color-mix(in srgb, var(--wc-gold) 20%, transparent);
+    box-shadow: inset 3px 0 0 var(--wc-gold);
+}
+.fifa-slot.winner .fifa-name { font-weight: 800; }
+.fifa-slot.winner::after {
+    content: "✓";
+    color: var(--wc-gold);
+    font-weight: 800;
+    font-size: 13px;
+    margin-left: 4px;
+}
+/* the champion's route through the bracket glows brighter than other winners */
+.fifa-slot.champ-path {
+    background: color-mix(in srgb, var(--wc-gold) 34%, transparent);
+    box-shadow: inset 3px 0 0 var(--wc-gold);
+}
+.fifa-slot.champ-path .fifa-name { font-weight: 800; }
+
+.fifa-slot.decided.loser { opacity: 0.55; }
+.fifa-slot.decided.loser .fifa-name {
+    text-decoration: line-through;
+    text-decoration-color: color-mix(in srgb, var(--foreground) 40%, transparent);
+}
+
+.fifa-match-no {
+    position: absolute;
+    top: 4px;
+    right: 7px;
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    color: color-mix(in srgb, var(--foreground) 22%, transparent);
+    pointer-events: none;
+    font-weight: 600;
+}
+
+.fifa-slot:focus-visible {
+    outline: 2px solid var(--wc-gold);
+    outline-offset: 2px;
+    z-index: 2;
+    border-radius: 4px;
+}
+
+/* ---------- Connectors ---------- */
+.fifa-col.left .fifa-pair:not(.solo)::after {
+    content: "";
+    position: absolute;
+    right: calc(var(--wc-gap) / -2);
+    top: 25%;
+    bottom: 25%;
+    width: calc(var(--wc-gap) / 2);
+    border: 2px solid var(--wc-line);
+    border-left: 0;
+    border-radius: 0 8px 8px 0;
+}
+.fifa-col.left .fifa-pair:not(.solo)::before {
+    content: "";
+    position: absolute;
+    right: calc(var(--wc-gap) * -1);
+    top: 50%;
+    width: calc(var(--wc-gap) / 2);
+    border-top: 2px solid var(--wc-line);
+}
+.fifa-col.right .fifa-pair:not(.solo)::after {
+    content: "";
+    position: absolute;
+    left: calc(var(--wc-gap) / -2);
+    top: 25%;
+    bottom: 25%;
+    width: calc(var(--wc-gap) / 2);
+    border: 2px solid var(--wc-line);
+    border-right: 0;
+    border-radius: 8px 0 0 8px;
+}
+.fifa-col.right .fifa-pair:not(.solo)::before {
+    content: "";
+    position: absolute;
+    left: calc(var(--wc-gap) * -1);
+    top: 50%;
+    width: calc(var(--wc-gap) / 2);
+    border-top: 2px solid var(--wc-line);
+}
+.fifa-col.left .fifa-pair.solo .fifa-match::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: calc(var(--wc-gap) * -1);
+    width: var(--wc-gap);
+    border-top: 2px solid var(--wc-line);
+}
+.fifa-col.right .fifa-pair.solo .fifa-match::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: calc(var(--wc-gap) * -1);
+    width: var(--wc-gap);
+    border-top: 2px solid var(--wc-line);
+}
+
+.fifa-hint {
+    text-align: center;
+    color: var(--muted-foreground);
+    font-size: 12px;
+    padding: 6px 0 12px;
+}
+
+@keyframes fifa-pop {
+    from { opacity: 0; transform: scale(0.97); }
+    to { opacity: 1; transform: scale(1); }
+}
+@keyframes fifa-sweep {
+    0% { left: -60%; }
+    55%, 100% { left: 130%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .fifa-champion,
+    .fifa-champion::after { animation: none; }
+    .fifa-slot { transition: none; }
+}
+
+@media (max-width: 720px) {
+    .fifa-topbar { padding: 12px 14px 8px; }
+    .fifa-champion { margin: 4px 14px 0; }
+    .fifa-scroll { padding: 14px; }
+    .fifa-slot { padding: 10px; }
+    .fifa-flag { width: 30px; height: 20px; }
+    .fifa-name { font-size: 16px; }
+}

--- a/web/src/pages/fifa/index.tsx
+++ b/web/src/pages/fifa/index.tsx
@@ -1,0 +1,12 @@
+import { Route, Routes } from "react-router";
+import { FifaPage } from "./fifa-page";
+import { PageNotFound } from "@/pages/404/page";
+
+export function FifaRouter() {
+    return (
+        <Routes>
+            <Route path="/" element={<FifaPage />} />
+            <Route path="*" element={<PageNotFound domain="lystic.dev/fifa" />} />
+        </Routes>
+    )
+}


### PR DESCRIPTION
Adds a FIFA World Cup 2026 knockout **bracket predictor** to the site, and introduces a collapsible **Playground** sidebar group (expanded by default) that now houses **Ping** and **FIFA Bracket**.

## What
- New `fifa` service router — works at `fifa.lystic.dev` and `lystic.dev/fifa`, registered in `SERVICE_ROUTERS` (same pattern as Ping/Blog).
- Ported the standalone bracket into the SPA: pure logic/data in `bracket.ts`, React page in `fifa-page.tsx`, scoped styles in `fifa.css`.
- Sidebar: added the **Playground** group, moved Ping into it, added FIFA Bracket (Trophy icon).

## Notes
- **Hybrid theming**: chrome follows the site's light/dark flexoki tokens; winners, the champion banner, and connectors keep a World-Cup gold accent. Verified in both light and dark.
- Flags are hotlinked from flagcdn.com.
- Features: click-to-advance with cascade, undo, simulate, reset, share-by-URL (`#b=` codec + paste-friendly recap), champion winning-path highlight, and fit-to-container sizing pinned to the viewport (no page scroll into blank space).
- Adds no new dependencies (reuses react-router, shadcn ui, lucide-react).

## Verification
- `tsc -b` and `eslint` clean; full `npm run build` succeeds.
- Visually checked empty/filled/champion states in light + dark, plus mobile/tablet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)