### PR TITLE
Building a Live-Only Weather Radar

### DIFF
--- a/web/public/blog/building-a-live-only-weather-radar/live-radar.png
+++ b/web/public/blog/building-a-live-only-weather-radar/live-radar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c64d6889755136b33ac419706ebdec0bd3b5680c726e3a67651ad954d4db2ae
+size 1158283

--- a/web/public/blog/building-a-live-only-weather-radar/radar-modes.png
+++ b/web/public/blog/building-a-live-only-weather-radar/radar-modes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1103eea3661733ebd5a5783e28ee656cc3a0d05b0506c2273873869f07929d6f
+size 577874

--- a/web/src/pages/blog/posts/2026/9. Building a Live-Only Weather Radar.mdx
+++ b/web/src/pages/blog/posts/2026/9. Building a Live-Only Weather Radar.mdx
@@ -1,0 +1,194 @@
+---
+title: Building a Live-Only Weather Radar
+description: |
+    I wanted a weather radar I could leave open while driving and understand with one glance,
+    which ruled out most of the controls that weather apps treat as mandatory. HyprRadar is the
+    result: a dark, live-only Flutter map backed by a Go API that never pretends an old scan is current.
+slug: building-a-live-only-weather-radar
+date: 2026-07-22
+tags: [flutter, go, mobile, weather]
+visible: false
+---
+
+# Building a Live-Only Weather Radar
+
+I wanted a weather radar I could leave open while driving and understand with one glance,
+which ruled out most of the controls that weather apps treat as mandatory. HyprRadar is the
+result: a dark, live-only Flutter map backed by a Go API that never pretends an old scan is current.
+
+Removing those controls sounds like a straightforward subtraction, but it turned into the main
+engineering problem. A slippy map is assembled from independently requested raster tiles, NOAA
+can publish a new observation while those tiles are loading, and my API is designed to run across
+more than one replica. If every tile request simply means "give me the latest image," one screen
+can quietly contain several different moments while still wearing a **LIVE** badge.
+
+I built [HyprRadar] around the opposite rule: the app asks for one observation, every tile is
+bound to it, and the old layer stays on screen until the replacement is ready. The repository
+contains the Flutter client, Go service, Kubernetes deployment, and the workflow that produces
+the signed Android release, so the interesting parts are all there to inspect.
+
+---
+
+The visible product is intentionally small. The default _Nearby radar_ mode opens on a dark
+[MapLibre] map with roads and place names, the device location, current reflectivity, active
+National Weather Service alert polygons, and an optional live-lightning layer. There is no
+forecast, playback loop, historical slider, or time selector.
+
+![HyprRadar showing live radar and weather alerts](/blog/building-a-live-only-weather-radar/live-radar.png)
+
+At broad zooms, the radar is the current quality-controlled [NWS RIDGE II] mosaic. It is really
+five regional NOAA layers covering the continental United States, Alaska, Hawaii, the Caribbean,
+and Guam. At zoom 7 the API can fetch only the local region, and at zoom 9 it can add one nearby
+WSR-88D station's super-resolution reflectivity across the whole viewport. The regional grid is
+roughly one kilometer; the station product is roughly 150 meters, so this adds actual detail
+instead of stretching the same pixels further.
+
+Choosing one station for the viewport matters. Picking a radar independently for each tile leaves
+hard seams where neighboring tiles choose different sites or scan times. HyprRadar follows the
+map center while browsing and the accepted device location while pinned, with a 20 km handoff
+margin so GPS movement near a boundary does not constantly rebuild the layer. If the station scan
+is unavailable or more than ten minutes behind its regional observation, the current mosaic stays
+visible underneath.
+
+Both reflectivity sources also use the same presentation floor of about 15 dBZ. The NOAA station
+image includes weak returns from things like insects, dust, ground clutter, and anomalous
+propagation that the quality-controlled mosaic has already removed. Filtering only the station
+layer made those blue echoes disappear and reappear whenever the mode changed, so the app applies
+one rain-focused floor to both. This is a display choice rather than meteorological quality
+control, and the legend says that weak returns are hidden.
+
+The station controls expose reflectivity and radial velocity, but only at the real `0.5°` tilt
+published by the current RIDGE service. The data model supports a list of elevations; the UI does
+not fill that list with several labels pointing at the same image. Higher tilts will require the
+Level-II ingest, decoder, and tile pipeline described in the repository rather than a convincing
+dropdown.
+
+---
+
+The backend's definition of _latest_ begins with a manifest. It includes `observedAt`,
+`receivedAt`, `checkedAt`, `ageSeconds`, and `stale`, plus an opaque 24-character version. For the
+aggregate view it also includes the exact observation time for every available region. The tile
+template carries that version and a compact signed snapshot of the component times.
+
+The signature is deliberately bound to both the binary payload and the public version:
+
+```go
+func signAggregateSnapshot(payload []byte, generation, key string) []byte {
+	mac := hmac.New(sha256.New, []byte(key))
+	domain := "radar.aggregate.v1\x00"
+	if len(payload) > 0 && payload[0] == aggregateSnapshotSchemaV2 {
+		domain = "radar.aggregate.v2\x00"
+	}
+	_, _ = mac.Write([]byte(domain))
+	_, _ = mac.Write([]byte(generation))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write(payload)
+	return mac.Sum(nil)[:aggregateSnapshotSignatureBytes]
+}
+```
+
+Schema 1 stores the five regional timestamps and a missing-region mask. Schema 2 adds the selected
+detail station, its exact scan time, and canonical coordinates. Any API replica with the shared
+HMAC key can validate the token and reconstruct the exact upstream WMS requests without a
+per-tile database lookup or access to the replica that created the manifest.
+
+This closes a surprisingly awkward race. Imagine the map requests twelve tiles from replica A,
+then NOAA publishes a scan before the remaining tiles reach replica B. Resolving `latest` inside
+each request produces a checkerboard of two observations. With the snapshot, each request carries
+the five times chosen before the first tile loaded, and the server sends those exact values in the
+upstream `TIME` parameter. A malformed, future-dated, mismatched, or tampered snapshot is rejected
+before it can cause upstream work.
+
+Station products use the same idea with a simpler generation. The API verifies that the requested
+scan still appears in NOAA's current WMS capabilities and allows a bounded 15-minute handoff after
+a newer scan appears, long enough for an existing map to finish loading. It never turns that grace
+period into a history endpoint, and an unlisted old timestamp is rejected rather than silently
+resolved to whatever is current now.
+
+---
+
+Generation-pinned URLs keep one layer internally consistent, but changing the URL still used to
+make the radar blink. A native raster source cannot change its tile template in place, so the first
+implementation removed the current source and installed the new one. That exposed the basemap
+while MapLibre fetched the replacement tiles.
+
+The client now treats its two native source slots as a small state machine. One is active while
+the other stages the next generation:
+
+```dart
+final candidate = RadarLayerCandidate(
+  slot: active.slot.other,
+  key: key,
+  resampling: resampling,
+);
+_pending = candidate;
+return RadarLayerTransition._(
+  kind: pending == null
+      ? RadarLayerTransitionKind.stage
+      : RadarLayerTransitionKind.supersede,
+  candidate: candidate,
+  retired: pending == null ? const [] : [pending],
+);
+```
+
+The pending layer is installed at `0.001` opacity rather than zero, which is enough to make the
+native renderer fetch its visible tiles without making it perceptible beneath the active layer.
+After MapLibre reports that the current viewport is idle, the client raises the pending layer to
+normal opacity and retires the old slot. If a newer scan arrives while that is happening, it
+supersedes only the hidden candidate; the complete image on screen is left alone.
+
+![HyprRadar's live radar mode controls](/blog/building-a-live-only-weather-radar/radar-modes.png)
+
+Reflectivity can use linear resampling during that swap, while radial velocity uses nearest
+neighbor because its color bins are categorical measurements. Crossfading those colors would
+invent values that the radar never reported.
+
+The update path is similarly conservative. Server-sent events announce new radar metadata while
+the app is in the foreground, with a 15-second poll as recovery after a disconnect or resume.
+Automatic alert refreshes join an in-flight request, and a manual retry during one queues a single
+follow-up instead of spawning duplicate work. When an upstream request fails, the last valid
+radar or alert geometry remains visible but is explicitly marked stale.
+
+---
+
+Radar ended up being only one of the live feeds on the map. The Go service polls the [NWS alerts
+API] once and fans the normalized result out to clients. Alerts with inline polygons are kept as
+published. Many NWS alerts identify forecast or county zones instead, so the service resolves
+those trusted zone geometries, caches them for 24 hours, and simplifies the combined shape before
+sending it to a phone. Tapping overlapping polygons opens a chooser rather than arbitrarily
+selecting the first warning under a finger.
+
+The optional lightning layer comes directly from the [GOES Geostationary Lightning Mapper] feeds
+for GOES-18 and GOES-19. The backend reads the short live window, removes duplicate and invalid
+records, and exposes approximate satellite-detected flash centroids over their own update stream.
+The first snapshot is a quiet baseline; only flashes first received afterward pulse on screen for
+about a second. The locations are delayed and approximate, and GLM measures total lightning rather
+than guaranteeing that a point was a cloud-to-ground strike.
+
+Location follows the same narrow contract. The normal map keeps the position on the device. The
+separately enabled _Near me_ background-alert mode rounds a fix to three decimal places and sends
+it only for a point-scoped NWS lookup; neither the app nor API writes that request coordinate to
+persistent storage. Android runs that check through [WorkManager] at roughly 15-minute intervals,
+which makes it useful supplemental notification rather than a replacement for Wireless Emergency
+Alerts or NOAA Weather Radio.
+
+That distinction is important throughout the project. Reflectivity is not exact rain at road
+level, radial velocity is movement toward or away from a station rather than surface wind, and a
+satellite flash centroid is not a strike-proximity alarm. The app can be direct about what each
+layer knows because it does not need to turn those feeds into a forecast or a safety claim.
+
+The source and the [signed Android APK] are available now. There is still plenty I want to do,
+especially the Level-II pipeline for real elevation selection, but the current version solves the
+thing I started with: open one map, glance at one coherent observation, and keep it current without
+pretending it is newer or more precise than it really is.
+
+Anyway, that's it. I thought this one was quite fun to build.
+
+{/* reference links */}
+[HyprRadar]: https://github.com/KeganHollern/radar-app
+[MapLibre]: https://github.com/maplibre/flutter-maplibre-gl
+[NWS RIDGE II]: https://www.weather.gov/radarfaq/
+[NWS alerts API]: https://www.weather.gov/documentation/services-web-alerts
+[GOES Geostationary Lightning Mapper]: https://goes-r.noaa.gov/spacesegment/glm.html
+[WorkManager]: https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work
+[signed Android APK]: https://github.com/KeganHollern/radar-app/releases/tag/v1.0.3

--- a/web/src/pages/blog/posts/2026/9. Building a Live-Only Weather Radar.mdx
+++ b/web/src/pages/blog/posts/2026/9. Building a Live-Only Weather Radar.mdx
@@ -2,8 +2,9 @@
 title: Building a Live-Only Weather Radar
 description: |
     I wanted a weather radar I could leave open while driving and understand with one glance,
-    which ruled out most of the controls that weather apps treat as mandatory. HyprRadar is the
-    result: a dark, live-only Flutter map backed by a Go API that never pretends an old scan is current.
+    without a forecast carousel or playback timeline. HyprRadar came out of that constraint, and
+    the annoying part was discovering how much work it takes to make LIVE mean one coherent thing
+    on a tiled map.
 slug: building-a-live-only-weather-radar
 date: 2026-07-22
 tags: [flutter, go, mobile, weather]
@@ -13,64 +14,50 @@ visible: false
 # Building a Live-Only Weather Radar
 
 I wanted a weather radar I could leave open while driving and understand with one glance,
-which ruled out most of the controls that weather apps treat as mandatory. HyprRadar is the
-result: a dark, live-only Flutter map backed by a Go API that never pretends an old scan is current.
+without a forecast carousel or playback timeline. HyprRadar came out of that constraint, and
+the annoying part was discovering how much work it takes to make LIVE mean one coherent thing
+on a tiled map.
 
-Removing those controls sounds like a straightforward subtraction, but it turned into the main
-engineering problem. A slippy map is assembled from independently requested raster tiles, NOAA
-can publish a new observation while those tiles are loading, and my API is designed to run across
-more than one replica. If every tile request simply means "give me the latest image," one screen
-can quietly contain several different moments while still wearing a **LIVE** badge.
+The first build loaded real radar and looked fine if I left it alone. Once the map moved or NOAA
+published another observation, three fairly reasonable assumptions started falling apart: a
+timestamp in a tile URL did not actually pin the tile, picking a nearby station for each part of
+the map produced seams, and replacing an old raster source with a new one made the weather blink
+out between scans.
 
-I built [HyprRadar] around the opposite rule: the app asks for one observation, every tile is
-bound to it, and the old layer stays on screen until the replacement is ready. The repository
-contains the Flutter client, Go service, Kubernetes deployment, and the workflow that produces
-the signed Android release, so the interesting parts are all there to inspect.
-
----
-
-The visible product is intentionally small. The default _Nearby radar_ mode opens on a dark
-[MapLibre] map with roads and place names, the device location, current reflectivity, active
-National Weather Service alert polygons, and an optional live-lightning layer. There is no
-forecast, playback loop, historical slider, or time selector.
+Those bugs all came from treating a radar layer like one image. [MapLibre] actually asks for a
+grid of images independently, sometimes through different API replicas, and it has no idea that
+twelve tile requests are supposed to describe the same moment. Most of the project ended up being
+about giving those requests a shared answer.
 
 ![HyprRadar showing live radar and weather alerts](/blog/building-a-live-only-weather-radar/live-radar.png)
 
-At broad zooms, the radar is the current quality-controlled [NWS RIDGE II] mosaic. It is really
-five regional NOAA layers covering the continental United States, Alaska, Hawaii, the Caribbean,
-and Guam. At zoom 7 the API can fetch only the local region, and at zoom 9 it can add one nearby
-WSR-88D station's super-resolution reflectivity across the whole viewport. The regional grid is
-roughly one kilometer; the station product is roughly 150 meters, so this adds actual detail
-instead of stretching the same pixels further.
-
-Choosing one station for the viewport matters. Picking a radar independently for each tile leaves
-hard seams where neighboring tiles choose different sites or scan times. HyprRadar follows the
-map center while browsing and the accepted device location while pinned, with a 20 km handoff
-margin so GPS movement near a boundary does not constantly rebuild the layer. If the station scan
-is unavailable or more than ten minutes behind its regional observation, the current mosaic stays
-visible underneath.
-
-Both reflectivity sources also use the same presentation floor of about 15 dBZ. The NOAA station
-image includes weak returns from things like insects, dust, ground clutter, and anomalous
-propagation that the quality-controlled mosaic has already removed. Filtering only the station
-layer made those blue echoes disappear and reappear whenever the mode changed, so the app applies
-one rain-focused floor to both. This is a display choice rather than meteorological quality
-control, and the legend says that weak returns are hidden.
-
-The station controls expose reflectivity and radial velocity, but only at the real `0.5°` tilt
-published by the current RIDGE service. The data model supports a list of elevations; the UI does
-not fill that list with several labels pointing at the same image. Higher tilts will require the
-Level-II ingest, decoder, and tile pipeline described in the repository rather than a convincing
-dropdown.
+The app itself is Flutter, backed by a Go API that talks to NOAA. At broad zooms it uses the five
+regional [NWS RIDGE II] reflectivity mosaics. At zoom 9 and above it can lay one station's roughly
+150-meter super-resolution scan over the roughly one-kilometer regional grid, which gives me real
+detail instead of a larger interpolation of the same pixels. Active NWS alert polygons and
+optional GOES lightning sit on the same map, but radar freshness is the part I refused to blur.
 
 ---
 
-The backend's definition of _latest_ begins with a manifest. It includes `observedAt`,
-`receivedAt`, `checkedAt`, `ageSeconds`, and `stale`, plus an opaque 24-character version. For the
-aggregate view it also includes the exact observation time for every available region. The tile
-template carries that version and a compact signed snapshot of the component times.
+I assumed the observation timestamp in my first tile template pinned the image. It didn't. The
+timestamp changed the cache key, but the API threw it away before making the WMS request and asked
+NOAA for whatever was newest at that instant.
 
-The signature is deliberately bound to both the binary payload and the public version:
+That is fine for one tile. A viewport needs several, and a scan can roll over between the first
+request and the last. The cache then preserves a neat checkerboard made from two observations
+under one **LIVE** badge. The aggregate view makes this slightly worse because it is not backed by
+one nationwide timestamp; CONUS, Alaska, Hawaii, the Caribbean, and Guam can each be on a different
+observation.
+
+My next pass carried a generation in every tile URL and remembered the matching regional times in
+a Go map for 15 minutes. That fixed the rollover on one process. The Kubernetes deployment has two
+API replicas, though, so a phone could get its manifest from replica A, cross a NOAA rollover, and
+send its remaining tiles to replica B, which had never seen the older generation.
+
+The current manifest carries the answer with it. Alongside a 24-character version, the tile URL
+contains a compact snapshot of the exact observation time for every available region. When nearby
+detail is enabled, the snapshot also includes the selected station, its scan time, and its
+coordinates. The whole payload is signed with a key shared by the API replicas:
 
 ```go
 func signAggregateSnapshot(payload []byte, generation, key string) []byte {
@@ -87,33 +74,58 @@ func signAggregateSnapshot(payload []byte, generation, key string) []byte {
 }
 ```
 
-Schema 1 stores the five regional timestamps and a missing-region mask. Schema 2 adds the selected
-detail station, its exact scan time, and canonical coordinates. Any API replica with the shared
-HMAC key can validate the token and reconstruct the exact upstream WMS requests without a
-per-tile database lookup or access to the replica that created the manifest.
+Any replica can validate that token and rebuild the exact `TIME` parameters without asking the
+replica that created it. Binding the signature to the public version also means a client cannot
+mix a valid payload with another generation or manufacture timestamps that make the API fetch
+arbitrary old scans.
 
-This closes a surprisingly awkward race. Imagine the map requests twelve tiles from replica A,
-then NOAA publishes a scan before the remaining tiles reach replica B. Resolving `latest` inside
-each request produces a checkerboard of two observations. With the snapshot, each request carries
-the five times chosen before the first tile loaded, and the server sends those exact values in the
-upstream `TIME` parameter. A malformed, future-dated, mismatched, or tampered snapshot is rejected
-before it can cause upstream work.
-
-Station products use the same idea with a simpler generation. The API verifies that the requested
-scan still appears in NOAA's current WMS capabilities and allows a bounded 15-minute handoff after
-a newer scan appears, long enough for an existing map to finish loading. It never turns that grace
-period into a history endpoint, and an unlisted old timestamp is rejected rather than silently
-resolved to whatever is current now.
+There is still a 15-minute handoff window because MapLibre may be finishing the old viewport when
+a new scan appears. That window is only there to let an already-issued layer finish loading. For
+station products, the API also verifies that the requested scan still appears in NOAA's current
+capabilities; an unlisted timestamp is rejected instead of being silently replaced with the new
+one. A tile either belongs to the requested generation or it does not render.
 
 ---
 
-Generation-pinned URLs keep one layer internally consistent, but changing the URL still used to
-make the radar blink. A native raster source cannot change its tile template in place, so the first
-implementation removed the current source and installed the new one. That exposed the basemap
-while MapLibre fetched the replacement tiles.
+The next bug showed up as a literal line through the weather around San Antonio. I had added the
+station detail tier by choosing a radar from each zoom-7 parent tile. Every child of that parent
+used the same station and scan, which sounded like enough to prevent seams. Two neighboring parent
+tiles could still choose different stations, and the boundary between them was exactly where the
+line appeared.
 
-The client now treats its two native source slots as a small state machine. One is active while
-the other stages the next generation:
+Choosing the station inside the tile handler was the wrong level. HyprRadar now picks one station
+for the entire viewport before it asks for the aggregate manifest. While browsing, the choice
+follows the map center; while location-follow is pinned, it follows the accepted device location.
+A new station has to be at least 20 km closer before the app switches, so small GPS movements near
+a handoff boundary do not continually replace the layer.
+
+The API then resolves one exact station scan and puts it into the signed snapshot with the five
+regional times. If that station image is unavailable or more than ten minutes behind its regional
+observation, it leaves the current mosaic underneath. Losing some detail is much less confusing
+than drawing an old storm cell over a newer base.
+
+![HyprRadar's live radar mode controls](/blog/building-a-live-only-weather-radar/radar-modes.png)
+
+There were two smaller display traps in the same area. The quality-controlled mosaic has already
+removed a lot of weak clutter, while a raw station image still contains insects, dust, and other
+returns below about 15 dBZ. Applying that floor only to station tiles made blue noise appear and
+disappear as the mode changed, so both reflectivity paths now use the same visible floor. Radial
+velocity keeps nearest-neighbor resampling because blending its color bins would imply values NOAA
+did not report.
+
+The station sheet also exposes only the real `0.5°` tilt that RIDGE currently publishes. The data
+model can hold more elevations, but I am not filling a dropdown with several labels for the same
+image. Real higher tilts need the Level-II ingest and tile path that is still on the project list.
+
+---
+
+Once every tile agreed on its source and time, updates still looked bad. A native MapLibre raster
+source cannot have its tile template changed in place, so my first implementation did the literal
+thing: remove the visible layer and source, then add replacements. The basemap showed through while
+the new tiles downloaded.
+
+HyprRadar now keeps two native source slots. One remains active while the other stages the next
+generation:
 
 ```dart
 final candidate = RadarLayerCandidate(
@@ -131,64 +143,31 @@ return RadarLayerTransition._(
 );
 ```
 
-The pending layer is installed at `0.001` opacity rather than zero, which is enough to make the
-native renderer fetch its visible tiles without making it perceptible beneath the active layer.
-After MapLibre reports that the current viewport is idle, the client raises the pending layer to
-normal opacity and retires the old slot. If a newer scan arrives while that is happening, it
-supersedes only the hidden candidate; the complete image on screen is left alone.
+The pending layer goes underneath the current one at `0.001` opacity. Zero opacity lets the native
+renderer decide there is nothing worth fetching; `0.001` keeps it renderable without making it
+visible through the active radar. Once MapLibre reports that the current viewport is idle, the app
+promotes the pending slot and removes the old one.
 
-![HyprRadar's live radar mode controls](/blog/building-a-live-only-weather-radar/radar-modes.png)
+This also handles the awkward case where NOAA publishes again while that replacement is loading.
+The newer generation supersedes only the hidden candidate. The complete layer on screen stays put
+until one replacement has loaded for the viewport the user is actually looking at, and moving the
+map clears any stale readiness signal before promotion.
 
-Reflectivity can use linear resampling during that swap, while radial velocity uses nearest
-neighbor because its color bins are categorical measurements. Crossfading those colors would
-invent values that the radar never reported.
+Server-sent events tell the app when radar metadata changes, and a 15-second poll repairs a dropped
+connection or an app resume. Neither path clears the screen first. If NOAA or the API fails, the
+last valid layer remains visible with stale status until a complete replacement is available.
 
-The update path is similarly conservative. Server-sent events announce new radar metadata while
-the app is in the foreground, with a 15-second poll as recovery after a disconnect or resume.
-Automatic alert refreshes join an in-flight request, and a manual retry during one queues a single
-follow-up instead of spawning duplicate work. When an upstream request fails, the last valid
-radar or alert geometry remains visible but is explicitly marked stale.
+That is what _live-only_ ended up meaning for this project. It is not merely the absence of a
+timeline; the observation has to remain fixed while its tiles load, survive a trip through any API
+replica, and stay on screen until the next complete observation can replace it.
 
----
-
-Radar ended up being only one of the live feeds on the map. The Go service polls the [NWS alerts
-API] once and fans the normalized result out to clients. Alerts with inline polygons are kept as
-published. Many NWS alerts identify forecast or county zones instead, so the service resolves
-those trusted zone geometries, caches them for 24 hours, and simplifies the combined shape before
-sending it to a phone. Tapping overlapping polygons opens a chooser rather than arbitrarily
-selecting the first warning under a finger.
-
-The optional lightning layer comes directly from the [GOES Geostationary Lightning Mapper] feeds
-for GOES-18 and GOES-19. The backend reads the short live window, removes duplicate and invalid
-records, and exposes approximate satellite-detected flash centroids over their own update stream.
-The first snapshot is a quiet baseline; only flashes first received afterward pulse on screen for
-about a second. The locations are delayed and approximate, and GLM measures total lightning rather
-than guaranteeing that a point was a cloud-to-ground strike.
-
-Location follows the same narrow contract. The normal map keeps the position on the device. The
-separately enabled _Near me_ background-alert mode rounds a fix to three decimal places and sends
-it only for a point-scoped NWS lookup; neither the app nor API writes that request coordinate to
-persistent storage. Android runs that check through [WorkManager] at roughly 15-minute intervals,
-which makes it useful supplemental notification rather than a replacement for Wireless Emergency
-Alerts or NOAA Weather Radio.
-
-That distinction is important throughout the project. Reflectivity is not exact rain at road
-level, radial velocity is movement toward or away from a station rather than surface wind, and a
-satellite flash centroid is not a strike-proximity alarm. The app can be direct about what each
-layer knows because it does not need to turn those feeds into a forecast or a safety claim.
-
-The source and the [signed Android APK] are available now. There is still plenty I want to do,
-especially the Level-II pipeline for real elevation selection, but the current version solves the
-thing I started with: open one map, glance at one coherent observation, and keep it current without
-pretending it is newer or more precise than it really is.
-
-Anyway, that's it. I thought this one was quite fun to build.
+The [source][HyprRadar] and [signed Android APK] are up now. I still want to build the Level-II path
+for real elevation selection, but the current version solves the annoyance I started with: I can
+leave one map open, glance at it, and stop wondering whether half of the screen belongs to a
+different scan.
 
 {/* reference links */}
 [HyprRadar]: https://github.com/KeganHollern/radar-app
 [MapLibre]: https://github.com/maplibre/flutter-maplibre-gl
 [NWS RIDGE II]: https://www.weather.gov/radarfaq/
-[NWS alerts API]: https://www.weather.gov/documentation/services-web-alerts
-[GOES Geostationary Lightning Mapper]: https://goes-r.noaa.gov/spacesegment/glm.html
-[WorkManager]: https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work
 [signed Android APK]: https://github.com/KeganHollern/radar-app/releases/tag/v1.0.3

--- a/web/src/pages/blog/posts/2026/9. Building a Live-Only Weather Radar.mdx
+++ b/web/src/pages/blog/posts/2026/9. Building a Live-Only Weather Radar.mdx
@@ -1,10 +1,8 @@
 ---
 title: Building a Live-Only Weather Radar
 description: |
-    I wanted a weather radar I could leave open while driving and understand with one glance,
-    without a forecast carousel or playback timeline. HyprRadar came out of that constraint, and
-    the annoying part was discovering how much work it takes to make LIVE mean one coherent thing
-    on a tiled map.
+    I kept checking weather radar while driving and getting a playback timeline when I only wanted
+    the newest scan. So I made HyprRadar a map I could leave open and understand with one glance.
 slug: building-a-live-only-weather-radar
 date: 2026-07-22
 tags: [flutter, go, mobile, weather]
@@ -13,21 +11,18 @@ visible: false
 
 # Building a Live-Only Weather Radar
 
-I wanted a weather radar I could leave open while driving and understand with one glance,
-without a forecast carousel or playback timeline. HyprRadar came out of that constraint, and
-the annoying part was discovering how much work it takes to make LIVE mean one coherent thing
-on a tiled map.
+I kept checking weather radar while driving and getting a playback timeline when I only wanted
+the newest scan. So I made HyprRadar a map I could leave open and understand with one glance.
 
-The first build loaded real radar and looked fine if I left it alone. Once the map moved or NOAA
-published another observation, three fairly reasonable assumptions started falling apart: a
-timestamp in a tile URL did not actually pin the tile, picking a nearby station for each part of
-the map produced seams, and replacing an old raster source with a new one made the weather blink
-out between scans.
+The first build looked correct as long as nothing changed. As soon as I panned the map or NOAA
+published another observation, it failed three different ways: the timestamp in a tile URL did
+not pin the tile, nearby station choices cut seams across the weather, and replacing a raster
+source made the whole layer disappear between scans.
 
 Those bugs all came from treating a radar layer like one image. [MapLibre] actually asks for a
 grid of images independently, sometimes through different API replicas, and it has no idea that
-twelve tile requests are supposed to describe the same moment. Most of the project ended up being
-about giving those requests a shared answer.
+twelve tile requests are supposed to describe the same observation. I had to make every one of
+those requests carry the same answer.
 
 ![HyprRadar showing live radar and weather alerts](/blog/building-a-live-only-weather-radar/live-radar.png)
 
@@ -39,20 +34,21 @@ optional GOES lightning sit on the same map, but radar freshness is the part I r
 
 ---
 
-I assumed the observation timestamp in my first tile template pinned the image. It didn't. The
-timestamp changed the cache key, but the API threw it away before making the WMS request and asked
-NOAA for whatever was newest at that instant.
+I assumed the observation timestamp in my first tile template pinned the image because every
+refresh produced a coherent-looking layer. The timestamp did change the cache key, but the API
+threw it away before making the WMS request and still asked NOAA for whatever was newest at that
+instant.
 
-That is fine for one tile. A viewport needs several, and a scan can roll over between the first
-request and the last. The cache then preserves a neat checkerboard made from two observations
-under one **LIVE** badge. The aggregate view makes this slightly worse because it is not backed by
-one nationwide timestamp; CONUS, Alaska, Hawaii, the Caribbean, and Guam can each be on a different
+It only broke during a rollover. A viewport needs several tiles, so the first requests could get
+one observation and the last could get the next. The cache then preserved both as a checkerboard
+under one **LIVE** badge. The aggregate view made this worse because it is not backed by one
+nationwide timestamp; CONUS, Alaska, Hawaii, the Caribbean, and Guam can each be on a different
 observation.
 
 My next pass carried a generation in every tile URL and remembered the matching regional times in
-a Go map for 15 minutes. That fixed the rollover on one process. The Kubernetes deployment has two
-API replicas, though, so a phone could get its manifest from replica A, cross a NOAA rollover, and
-send its remaining tiles to replica B, which had never seen the older generation.
+a Go map for 15 minutes. It worked on one process. The Kubernetes deployment has two API replicas,
+so a phone could get its manifest from replica A, cross a NOAA rollover, and send its remaining
+tiles to replica B, which had never seen the older generation.
 
 The current manifest carries the answer with it. Alongside a 24-character version, the tile URL
 contains a compact snapshot of the exact observation time for every available region. When nearby
@@ -79,11 +75,10 @@ replica that created it. Binding the signature to the public version also means 
 mix a valid payload with another generation or manufacture timestamps that make the API fetch
 arbitrary old scans.
 
-There is still a 15-minute handoff window because MapLibre may be finishing the old viewport when
-a new scan appears. That window is only there to let an already-issued layer finish loading. For
-station products, the API also verifies that the requested scan still appears in NOAA's current
-capabilities; an unlisted timestamp is rejected instead of being silently replaced with the new
-one. A tile either belongs to the requested generation or it does not render.
+The API keeps already-issued snapshots valid for 15 minutes because MapLibre may still be finishing
+the old viewport when a new scan appears. For station products, it also verifies that the requested
+scan still appears in NOAA's current capabilities. If it does not, the API rejects the tile instead
+of silently replacing the timestamp with the newest one.
 
 ---
 
@@ -101,8 +96,8 @@ a handoff boundary do not continually replace the layer.
 
 The API then resolves one exact station scan and puts it into the signed snapshot with the five
 regional times. If that station image is unavailable or more than ten minutes behind its regional
-observation, it leaves the current mosaic underneath. Losing some detail is much less confusing
-than drawing an old storm cell over a newer base.
+observation, HyprRadar keeps the current mosaic underneath instead of drawing an older, sharper
+storm cell over a newer base.
 
 ![HyprRadar's live radar mode controls](/blog/building-a-live-only-weather-radar/radar-modes.png)
 
@@ -122,7 +117,7 @@ image. Real higher tilts need the Level-II ingest and tile path that is still on
 Once every tile agreed on its source and time, updates still looked bad. A native MapLibre raster
 source cannot have its tile template changed in place, so my first implementation did the literal
 thing: remove the visible layer and source, then add replacements. The basemap showed through while
-the new tiles downloaded.
+the new tiles downloaded, which meant every successful refresh briefly erased the radar.
 
 HyprRadar now keeps two native source slots. One remains active while the other stages the next
 generation:
@@ -148,23 +143,24 @@ renderer decide there is nothing worth fetching; `0.001` keeps it renderable wit
 visible through the active radar. Once MapLibre reports that the current viewport is idle, the app
 promotes the pending slot and removes the old one.
 
-This also handles the awkward case where NOAA publishes again while that replacement is loading.
-The newer generation supersedes only the hidden candidate. The complete layer on screen stays put
+NOAA can publish another observation while that replacement is still loading. When that happens,
+the newer generation supersedes only the hidden candidate. The complete layer on screen stays put
 until one replacement has loaded for the viewport the user is actually looking at, and moving the
 map clears any stale readiness signal before promotion.
 
-Server-sent events tell the app when radar metadata changes, and a 15-second poll repairs a dropped
-connection or an app resume. Neither path clears the screen first. If NOAA or the API fails, the
-last valid layer remains visible with stale status until a complete replacement is available.
+Server-sent events trigger the normal refresh, and a 15-second poll repairs a dropped connection or
+an app resume. Both feed the same staged swap, so neither clears the screen first. If NOAA or the
+API fails, the last valid layer remains visible with stale status until a complete replacement is
+available.
 
-That is what _live-only_ ended up meaning for this project. It is not merely the absence of a
-timeline; the observation has to remain fixed while its tiles load, survive a trip through any API
-replica, and stay on screen until the next complete observation can replace it.
+For HyprRadar, _live-only_ now means more than removing a timeline. The observation stays fixed
+while its tiles load, any API replica can serve it, and the old layer remains on screen until the
+next observation is complete.
 
-The [source][HyprRadar] and [signed Android APK] are up now. I still want to build the Level-II path
-for real elevation selection, but the current version solves the annoyance I started with: I can
-leave one map open, glance at it, and stop wondering whether half of the screen belongs to a
-different scan.
+The [source][HyprRadar] and [signed Android APK] are up. Level-II is still on my list because that
+is what real elevation selection needs. The current version handles the thing that kept bothering
+me: I can leave one map open, glance at it, and stop wondering whether half of the screen belongs
+to a different scan.
 
 {/* reference links */}
 [HyprRadar]: https://github.com/KeganHollern/radar-app


### PR DESCRIPTION
## Summary

- Adds a new draft post about the engineering behind HyprRadar and its deliberately live-only product boundary.
- Covers generation-pinned NOAA tiles, replica-safe signed snapshots, station detail, double-buffered MapLibre layers, NWS alerts, and live GOES lightning.
- Includes two genuine in-app screenshots under the post slug directory.
- Keeps `visible: false` while the post is under review.

## Screenshot provenance

The screenshots were captured directly with `adb exec-out screencap` from the signed `hyprradar-v1.0.3-android.apk` release on an Android 15 x86_64 emulator. This host has no `/dev/kvm`, so the emulator ran with software CPU emulation and SwiftShader. The app used `https://radar.lystic.dev` and an Android test-provider location near Nashville while active radar and NWS alert data were present. The frames are direct app output, not generated UI.

## Cover status

The mandated `generate-image` workflow was attempted, but it failed fast because `XAI_API_KEY` is not exported. Per the blog skill, this draft omits the cover asset and the `image` frontmatter field.

Prompt used:

> High-contrast stenciled propaganda-poster illustration, two-tone palette of off-white and a single bold red-orange accent on charcoal, halftone and paper texture, bold silhouette focal motif, no text, no letters, no logos, no symbols. Subject: a hand holding a vertical smartphone over a simplified road grid as a broad storm-cell silhouette moves across the screen, with the red-orange accent concentrated on the weather cell and its leading edge.

## Checks

- `cd web && npm run check:posts` — pass
- `cd web && npm run build` — pass

The first local build encountered pre-existing Git LFS pointer stubs because Git LFS was not installed in this clone. After installing Git LFS and hydrating the existing objects, the full build passed.